### PR TITLE
fix: job log is not written if job underflows chunk size

### DIFF
--- a/dabapush/Writer/Writer.py
+++ b/dabapush/Writer/Writer.py
@@ -30,7 +30,7 @@ class Writer:
 
     def __del__(self):
         """Ensures the buffer is flushed before the object is destroyed."""
-        self.persist()
+        self._trigger_persist()
 
     def write(self, queue: Iterator[Record]) -> None:
         """Consumes items from the provided queue.
@@ -41,14 +41,15 @@ class Writer:
         for item in queue:
             self.buffer.append(item)
             if len(self.buffer) >= self.config.chunk_size:
-                self.persist()
-                log.debug(
-                    f"Persisted {self.config.chunk_size} records. Setting to done."
-                )
-                for record in self.buffer:
-                    log.debug(f"Setting record {record.uuid} as done.")
-                    record.done()
-                self.buffer = []
+                self._trigger_persist()
+
+    def _trigger_persist(self):
+        self.persist()
+        log.debug(f"Persisted {self.config.chunk_size} records. Setting to done.")
+        for record in self.buffer:
+            log.debug(f"Setting record {record.uuid} as done.")
+            record.done()
+        self.buffer = []
 
     @abc.abstractmethod
     def persist(self) -> None:

--- a/dabapush/Writer/ndjson_writer.py
+++ b/dabapush/Writer/ndjson_writer.py
@@ -22,7 +22,6 @@ class NDJSONWriter(Writer):
         """Persist the buffer to the file and flush."""
 
         last_rows = self.buffer
-        self.buffer = []
 
         _file: Path = Path(self.config.path) / self.config.make_file_name(
             additional_keys={"type": "ndjson"}

--- a/dabapush/Writer/stdout_writer.py
+++ b/dabapush/Writer/stdout_writer.py
@@ -13,7 +13,7 @@ class STDOUTWriter(Writer):
     def persist(self):
         last_rows = self.buffer
         for row in last_rows:
-            print(row)
+            print(row.payload)
 
 
 class STDOUTWriterConfiguration(WriterConfiguration):

--- a/tests/Writer/test_Writer.py
+++ b/tests/Writer/test_Writer.py
@@ -24,7 +24,7 @@ def test_id(writer: Writer):
 
 def test_writer_write_method(writer: Writer):
     """Should write to the buffer."""
-    queue = (Record(i, i) for i in range(10))
+    queue = (Record(i, uuid=str(i)) for i in range(10))
     writer.write(queue)
     assert [_.payload for _ in writer.buffer] == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 

--- a/tests/Writer/test_stdout_writer.py
+++ b/tests/Writer/test_stdout_writer.py
@@ -1,12 +1,13 @@
 """Test the STDOUTWriter class."""
 
 from dabapush import STDOUTWriterConfiguration
+from dabapush.Record import Record
 
 
 def test_stdout_writer(capsys):
     """Should write to stdout."""
     writer = STDOUTWriterConfiguration("stdout1").get_instance()
-    writer.buffer = ["test"]
+    writer.buffer = [Record(uuid="test.01", source=None, payload="test")]
     writer.persist()
 
     captured = capsys.readouterr()


### PR DESCRIPTION
This refactors the logging trigger so that is trigger regardless of whether if has been deemed necessary via a buffer overflow or writer deletion.

Extra: fixes some bugs in the tests.

Closes #74.