### PR TITLE
DBM backlog

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Test with pytest
         run: poetry run pytest --cov-report html:coverage-${{ matrix.python-version }}
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-results-${{ matrix.python-version }}
           path: coverage-${{ matrix.python-version }}

--- a/dabapush/Backlog.py
+++ b/dabapush/Backlog.py
@@ -1,7 +1,8 @@
 "Backlog for keeping track of already written records."
+
+import dbm
 from pathlib import Path
 from shutil import copy
-from sqlite3 import IntegrityError, connect
 from typing import Any, Dict, List, Union
 
 import ujson
@@ -9,11 +10,9 @@ import ujson
 from .Configuration.WriterConfiguration import WriterConfiguration
 from .Record import Record
 
-_backlog_table_name = "dabapush_backlog"
-
 
 class BacklogLockedException(Exception):
-    "Raised when trying to open a locked backlog"
+    """Raised when trying to open a locked backlog"""
 
     def __init__(self):
         super().__init__("Can not open locked backlog.")
@@ -40,11 +39,11 @@ class Backlog:
             writer_config: The config used for the writer.
                 This is mainly used for getting the name."""
         self.writer_config = writer_config
-        self._sqlite_connection = None
+        self._db_connection = None
         self._locked = False
 
     def load(self):
-        "Load the backlog from the file system."
+        """Load the backlog from the file system."""
         dabapush_dir = Path(".dabapush")
         if not dabapush_dir.exists():
             dabapush_dir.mkdir()
@@ -57,36 +56,27 @@ class Backlog:
         self._log_lock_path.touch()
         self._locked = True
         self._init_db()
+        self._load_db()
+
         log_file_pth = dabapush_dir / f"{self.writer_config.name}.jsonl"
         if log_file_pth.exists():
             self._convert_log(log_file_pth)
             copy(log_file_pth, log_file_pth.with_suffix(log_file_pth.suffix + ".old"))
             log_file_pth.unlink()
-        self._load_db()
 
     def _convert_log(self, log_file_pth):
-        self._init_db()
         with open(log_file_pth, "rt", encoding="utf8") as log_file:
             for line in log_file.readlines():
                 record_json = ujson.loads(line)  # pylint: disable=c-extension-no-member
                 self._write_json_record(record_json)
 
     def _init_db(self):
-        if self._sqlite_connection is None:
-            self._sqlite_connection = connect(self._backlog_db_path.as_posix())
-        columns = self._sqlite_connection.execute(
-            f"""SELECT name
-            FROM sqlite_schema
-            WHERE name='{_backlog_table_name}'"""
-        )
-        column = columns.fetchone()
-        if column is None:
-            self._sqlite_connection.execute(
-                f"""CREATE TABLE {_backlog_table_name}(uuid TEXT PRIMARY KEY, record)"""
-            )
+        if not self._backlog_db_path.exists():
+            _db = dbm.open(self._backlog_db_path.as_posix(), "n")
+            _db.close()
 
     def write_record(self, record: Record):
-        "Persist a record to the log"
+        """Persist a record to the log"""
         if self._locked:
             log_dict = record.to_log()
             self._write_json_record(log_dict)
@@ -97,7 +87,7 @@ class Backlog:
 
     @property
     def _backlog_db_path(self) -> Path:
-        return self._backlog_root_dir / "backlog.sqlite3"
+        return self._backlog_root_dir / "backlog.db"
 
     @property
     def _backlog_root_dir(self) -> Path:
@@ -107,44 +97,30 @@ class Backlog:
         self, record_dict: Dict[str, Union[str, List[Dict[str, Any]]]]
     ):
         uuid = record_dict["uuid"]
-        try:
-            self._sqlite_connection.execute(
-                f"""INSERT INTO {_backlog_table_name} VALUES
-                    (:uuid, :record)""",
-                {
-                    "uuid": uuid,
-                    "record": ujson.dumps(  # pylint: disable=c-extension-no-member
-                        record_dict
-                    ),
-                },
-            )
-            self._sqlite_connection.commit()
-        except IntegrityError as exc:
-            raise UuidExistsException(uuid) from exc
+        if uuid in self._db_connection:
+            raise UuidExistsException(uuid)
+        self._db_connection[uuid] = ujson.dumps(
+            record_dict
+        )  # pylint: disable=c-extension-no-member
 
     def _load_db(self):
-        if self._sqlite_connection is None:
-            self._sqlite_connection = connect(self._backlog_db_path.as_posix())
+        if self._db_connection is None:
+            self._db_connection = dbm.open(self._backlog_db_path.as_posix(), "w")
 
     def __contains__(self, item: Record):
         if not isinstance(item, Record):
             raise TypeError("Can only check for the the presence of records")
         uuid = item.uuid
-        results = self._sqlite_connection.execute(
-            f"""SELECT uuid
-            from {_backlog_table_name}
-            where uuid='{uuid}'"""
-        )
-        return results.fetchone() is not None
+        return uuid in self._db_connection
 
     def close(self):
-        "Unlocks the log."
+        """Unlocks the log."""
         lock_pth = self._log_lock_path
         if lock_pth.exists():
             lock_pth.unlink()
         self._locked = False
-        if self._sqlite_connection is not None:
-            self._sqlite_connection.close()
+        if self._db_connection is not None:
+            self._db_connection.close()
 
     def __del__(self):
         self.close()

--- a/dabapush/Backlog.py
+++ b/dabapush/Backlog.py
@@ -1,20 +1,29 @@
-from collections import defaultdict
-from hashlib import md5
-from typing import Any, Dict, List, Union
-from itertools import accumulate, islice
+"Backlog for keeping track of already written records."
 from pathlib import Path
-from ujson import loads, dump
+from sqlite3 import IntegrityError, connect
+from typing import Any, Dict, List, Union
+
+import ujson
 
 from .Configuration.WriterConfiguration import WriterConfiguration
 from .Record import Record
 
-_HEX_CHARS = "0123456789abcdef"
+_backlog_table_name = "dabapush_backlog"
 
 
 class BacklogLockedException(Exception):
     "Raised when trying to open a locked backlog"
+
     def __init__(self):
         super().__init__("Can not open locked backlog.")
+
+
+class UuidExistsException(Exception):
+    """Raise when an entry exists in the db
+    with the same uuid as the written record"""
+
+    def __init__(self, uuid):
+        super().__init__(f"Record with uuid {uuid} already exists in the db.")
 
 
 class Backlog:
@@ -22,22 +31,15 @@ class Backlog:
 
     def __init__(
         self,
-        len_prefix_persist: int,
-        len_prefix_memory: int,
         writer_config: WriterConfiguration,
     ):
         """Initialize the backlog configuration.
 
         Args:
-            len_prefix_persist: Number of digits used for partitioning the log.
-                Will result in 16 ** len_prefix_persist files on disk.
-            len_prefix_memory: Number of digits used for partitioning the in memory log.
             writer_config: The config used for the writer.
                 This is mainly used for getting the name."""
-        self.len_prefix_persist = len_prefix_persist
-        self.len_prefix_memory = len_prefix_memory
         self.writer_config = writer_config
-        self.parts = defaultdict(set)
+        self._sqlite_connection = None
         self._locked = False
 
     def load(self):
@@ -53,49 +55,47 @@ class Backlog:
             raise BacklogLockedException()
         self._log_lock_path.touch()
         self._locked = True
-        self._init_dirs()
+        self._init_db()
         log_file_pth = dabapush_dir / f"{self.writer_config.name}.jsonl"
         if log_file_pth.exists():
             self._convert_log(log_file_pth)
             log_file_pth.unlink()
-        self._load_dir()
+        self._load_db()
 
     def _convert_log(self, log_file_pth):
-        self._init_dirs()
+        self._init_db()
         with open(log_file_pth, "rt", encoding="utf8") as log_file:
             for line in log_file.readlines():
-                record_json = loads(line)
+                record_json = ujson.loads(line)  # pylint: disable=c-extension-no-member
                 self._write_json_record(record_json)
 
-    def _init_dirs(self):
-        log_dir = self._backlog_root_dir
-        file_prefixes = next(
-            islice(
-                accumulate(
-                    [_HEX_CHARS] * self.len_prefix_persist,
-                    lambda chars0, chars1: [
-                        char0 + char1 for char0 in chars0 for char1 in chars1
-                    ],
-                ),
-                self.len_prefix_persist - 1,
-                self.len_prefix_persist,
-            )
+    def _init_db(self):
+        if self._sqlite_connection is None:
+            self._sqlite_connection = connect(self._backlog_db_path.as_posix())
+        columns = self._sqlite_connection.execute(
+            f"""SELECT name
+            FROM sqlite_schema
+            WHERE name='{_backlog_table_name}'"""
         )
-        for prefix in file_prefixes:
-            file_pth = log_dir / (prefix + ".jsonl")
-            if not file_pth.exists():
-                file_pth.touch()
+        column = columns.fetchone()
+        if column is None:
+            self._sqlite_connection.execute(
+                f"""CREATE TABLE {_backlog_table_name}(uuid TEXT PRIMARY KEY, record)"""
+            )
 
     def write_record(self, record: Record):
         "Persist a record to the log"
         if self._locked:
             log_dict = record.to_log()
             self._write_json_record(log_dict)
-            self._store_in_memory(log_dict)
 
     @property
     def _log_lock_path(self) -> Path:
         return self._backlog_root_dir / "lock"
+
+    @property
+    def _backlog_db_path(self) -> Path:
+        return self._backlog_root_dir / "backlog.sqlite3"
 
     @property
     def _backlog_root_dir(self) -> Path:
@@ -105,38 +105,35 @@ class Backlog:
         self, record_dict: Dict[str, Union[str, List[Dict[str, Any]]]]
     ):
         uuid = record_dict["uuid"]
-        persist_prefix = md5(uuid.encode()).hexdigest()[: self.len_prefix_persist]
-        with (self._backlog_root_dir / f"{persist_prefix}.jsonl").open(
-            "+wt", encoding="utf8"
-        ) as out_file:
-            dump(record_dict, out_file)
-            out_file.write("\n")
+        try:
+            self._sqlite_connection.execute(
+                f"""INSERT INTO {_backlog_table_name} VALUES
+                    (:uuid, :record)""",
+                {
+                    "uuid": uuid,
+                    "record": ujson.dumps(  # pylint: disable=c-extension-no-member
+                        record_dict
+                    ),
+                },
+            )
+            self._sqlite_connection.commit()
+        except IntegrityError as exc:
+            raise UuidExistsException(uuid) from exc
 
-    def _load_dir(self):
-        log_dir = self._backlog_root_dir
-        for chunk_pth in log_dir.glob("*.jsonl"):
-            with chunk_pth.open("rt", encoding="utf8") as chunk_file:
-                for line in chunk_file.readlines():
-                    record_dict = loads(line)
-                    uuid = record_dict["uuid"]
-                    memory_prefix = md5(uuid.encode()).hexdigest()[
-                        : self.len_prefix_memory
-                    ]
-                    self.parts[memory_prefix].add(uuid)
+    def _load_db(self):
+        if self._sqlite_connection is None:
+            self._sqlite_connection = connect(self._backlog_db_path.as_posix())
 
     def __contains__(self, item: Record):
         if not isinstance(item, Record):
             raise TypeError("Can only check for the the presence of records")
         uuid = item.uuid
-        memory_prefix = md5(uuid.encode()).hexdigest()[: self.len_prefix_memory]
-        return uuid in self.parts[memory_prefix]
-
-    def _store_in_memory(
-        self, record_dict: Dict[str, Union[str, List[Dict[str, Any]]]]
-    ):
-        uuid = record_dict["uuid"]
-        memory_prefix = md5(uuid.encode()).hexdigest()[: self.len_prefix_memory]
-        self.parts[memory_prefix].add(uuid)
+        results = self._sqlite_connection.execute(
+            f"""SELECT uuid
+            from {_backlog_table_name}
+            where uuid='{uuid}'"""
+        )
+        return results.fetchone() is not None
 
     def close(self):
         "Unlocks the log."
@@ -144,6 +141,8 @@ class Backlog:
         if lock_pth.exists():
             lock_pth.unlink()
         self._locked = False
+        if self._sqlite_connection is not None:
+            self._sqlite_connection.close()
 
     def __del__(self):
         self.close()

--- a/dabapush/Backlog.py
+++ b/dabapush/Backlog.py
@@ -1,0 +1,149 @@
+from collections import defaultdict
+from hashlib import md5
+from typing import Any, Dict, List, Union
+from itertools import accumulate, islice
+from pathlib import Path
+from ujson import loads, dump
+
+from .Configuration.WriterConfiguration import WriterConfiguration
+from .Record import Record
+
+_HEX_CHARS = "0123456789abcdef"
+
+
+class BacklogLockedException(Exception):
+    "Raised when trying to open a locked backlog"
+    def __init__(self):
+        super().__init__("Can not open locked backlog.")
+
+
+class Backlog:
+    """A backlog for keeping track of written Records."""
+
+    def __init__(
+        self,
+        len_prefix_persist: int,
+        len_prefix_memory: int,
+        writer_config: WriterConfiguration,
+    ):
+        """Initialize the backlog configuration.
+
+        Args:
+            len_prefix_persist: Number of digits used for partitioning the log.
+                Will result in 16 ** len_prefix_persist files on disk.
+            len_prefix_memory: Number of digits used for partitioning the in memory log.
+            writer_config: The config used for the writer.
+                This is mainly used for getting the name."""
+        self.len_prefix_persist = len_prefix_persist
+        self.len_prefix_memory = len_prefix_memory
+        self.writer_config = writer_config
+        self.parts = defaultdict(set)
+        self._locked = False
+
+    def load(self):
+        "Load the backlog from the file system."
+        dabapush_dir = Path(".dabapush")
+        if not dabapush_dir.exists():
+            dabapush_dir.mkdir()
+        log_dir = self._backlog_root_dir
+        if not log_dir.exists():
+            log_dir.mkdir(parents=True)
+
+        if self._log_lock_path.exists():
+            raise BacklogLockedException()
+        self._log_lock_path.touch()
+        self._locked = True
+        self._init_dirs()
+        log_file_pth = dabapush_dir / f"{self.writer_config.name}.jsonl"
+        if log_file_pth.exists():
+            self._convert_log(log_file_pth)
+            log_file_pth.unlink()
+        self._load_dir()
+
+    def _convert_log(self, log_file_pth):
+        self._init_dirs()
+        with open(log_file_pth, "rt", encoding="utf8") as log_file:
+            for line in log_file.readlines():
+                record_json = loads(line)
+                self._write_json_record(record_json)
+
+    def _init_dirs(self):
+        log_dir = self._backlog_root_dir
+        file_prefixes = next(
+            islice(
+                accumulate(
+                    [_HEX_CHARS] * self.len_prefix_persist,
+                    lambda chars0, chars1: [
+                        char0 + char1 for char0 in chars0 for char1 in chars1
+                    ],
+                ),
+                self.len_prefix_persist - 1,
+                self.len_prefix_persist,
+            )
+        )
+        for prefix in file_prefixes:
+            file_pth = log_dir / (prefix + ".jsonl")
+            if not file_pth.exists():
+                file_pth.touch()
+
+    def write_record(self, record: Record):
+        "Persist a record to the log"
+        if self._locked:
+            log_dict = record.to_log()
+            self._write_json_record(log_dict)
+            self._store_in_memory(log_dict)
+
+    @property
+    def _log_lock_path(self) -> Path:
+        return self._backlog_root_dir / "lock"
+
+    @property
+    def _backlog_root_dir(self) -> Path:
+        return Path(f".dabapush/{self.writer_config.name}/backlog")
+
+    def _write_json_record(
+        self, record_dict: Dict[str, Union[str, List[Dict[str, Any]]]]
+    ):
+        uuid = record_dict["uuid"]
+        persist_prefix = md5(uuid.encode()).hexdigest()[: self.len_prefix_persist]
+        with (self._backlog_root_dir / f"{persist_prefix}.jsonl").open(
+            "+wt", encoding="utf8"
+        ) as out_file:
+            dump(record_dict, out_file)
+            out_file.write("\n")
+
+    def _load_dir(self):
+        log_dir = self._backlog_root_dir
+        for chunk_pth in log_dir.glob("*.jsonl"):
+            with chunk_pth.open("rt", encoding="utf8") as chunk_file:
+                for line in chunk_file.readlines():
+                    record_dict = loads(line)
+                    uuid = record_dict["uuid"]
+                    memory_prefix = md5(uuid.encode()).hexdigest()[
+                        : self.len_prefix_memory
+                    ]
+                    self.parts[memory_prefix].add(uuid)
+
+    def __contains__(self, item: Record):
+        if not isinstance(item, Record):
+            raise TypeError("Can only check for the the presence of records")
+        uuid = item.uuid
+        memory_prefix = md5(uuid.encode()).hexdigest()[: self.len_prefix_memory]
+        return uuid in self.parts[memory_prefix]
+
+    def _store_in_memory(
+        self, record_dict: Dict[str, Union[str, List[Dict[str, Any]]]]
+    ):
+        uuid = record_dict["uuid"]
+        memory_prefix = md5(uuid.encode()).hexdigest()[: self.len_prefix_memory]
+        self.parts[memory_prefix].add(uuid)
+
+    def close(self):
+        "Unlocks the log."
+        lock_pth = self._log_lock_path
+        if lock_pth.exists():
+            lock_pth.unlink()
+        self._locked = False
+
+    def __del__(self):
+        self.close()

--- a/dabapush/Backlog.py
+++ b/dabapush/Backlog.py
@@ -1,5 +1,6 @@
 "Backlog for keeping track of already written records."
 from pathlib import Path
+from shutil import copy
 from sqlite3 import IntegrityError, connect
 from typing import Any, Dict, List, Union
 
@@ -59,6 +60,7 @@ class Backlog:
         log_file_pth = dabapush_dir / f"{self.writer_config.name}.jsonl"
         if log_file_pth.exists():
             self._convert_log(log_file_pth)
+            copy(log_file_pth, log_file_pth.with_suffix(log_file_pth.suffix + ".old"))
             log_file_pth.unlink()
         self._load_db()
 

--- a/dabapush/Writer/Writer.py
+++ b/dabapush/Writer/Writer.py
@@ -12,6 +12,7 @@ from typing import Iterator, List
 import ujson
 from loguru import logger as log
 
+from ..Backlog import Backlog
 from ..Configuration.WriterConfiguration import WriterConfiguration
 from ..Record import Record
 
@@ -29,31 +30,20 @@ class Writer:
 
         self.config = config
         self.buffer: List[Record] = []
-        self.back_log: List[Record] = []
         # initialize file log
         if not Path(".dabapush/").exists():
             Path(".dabapush/").mkdir()
 
         self.log_path = Path(f".dabapush/{config.name}.jsonl")
-        if self.log_path.exists():
-            log.debug(
-                f"Found log file for {self.config.name} at {self.log_path}. Loading..."
-            )
-            with self.log_path.open("rt", encoding="utf8") as f:
-                self.back_log = [
-                    Record(**ujson.loads(_))  # pylint: disable=I1101
-                    for _ in f.readlines()
-                ]
-        else:
-            self.log_path.touch()
-        self.log_file = self.log_path.open(  # pylint: disable=R1732
-            "a", encoding="utf8"
+        self.back_log = Backlog(
+            len_prefix_persist=2, len_prefix_memory=2, writer_config=config
         )
+        self.back_log.load()
 
     def __del__(self):
         """Ensures the buffer is flushed before the object is destroyed."""
         self._trigger_persist()
-        self.log_file.close()
+        self.back_log.close()
 
     def write(self, queue: Iterator[Record]) -> None:
         """Consumes items from the provided queue.
@@ -75,7 +65,6 @@ class Writer:
             log.debug(f"Setting record {record.uuid} as done.")
             record.done()
             self.log(record)
-            self.log_file.flush()
         self.buffer = []
 
     @abc.abstractmethod
@@ -102,7 +91,6 @@ class Writer:
 
     def log(self, record: Record):
         """Log the record to the persistent record log file."""
-        ujson.dump(record.to_log(), self.log_file)  # pylint: disable=I1101
-        self.log_file.write("\n")
+        self.back_log.write_record(record)
 
         log.debug(f"Done with {record.uuid}")

--- a/dabapush/Writer/Writer.py
+++ b/dabapush/Writer/Writer.py
@@ -9,7 +9,6 @@ import abc
 from pathlib import Path
 from typing import Iterator, List
 
-import ujson
 from loguru import logger as log
 
 from ..Backlog import Backlog
@@ -35,9 +34,7 @@ class Writer:
             Path(".dabapush/").mkdir()
 
         self.log_path = Path(f".dabapush/{config.name}.jsonl")
-        self.back_log = Backlog(
-            len_prefix_persist=2, len_prefix_memory=2, writer_config=config
-        )
+        self.back_log = Backlog(writer_config=config)
         self.back_log.load()
 
     def __del__(self):

--- a/tests/Reader/test_reader.py
+++ b/tests/Reader/test_reader.py
@@ -29,9 +29,10 @@ def test_backlogging(monkeypatch, tmp_path):
 
     writer.write(reader.read())
 
-    log_path = Path(".dabapush/test.jsonl")
+    log_path = Path(".dabapush/test/backlog")
     assert log_path.exists()
-    with log_path.open("rt", encoding="utf8") as f:
-        content = f.readlines()
-        # assert content != []
-        assert len(content) == len(records)
+    content_count = 0
+    for file_path in log_path.glob('*.jsonl'):
+        with file_path.open("rt", encoding="utf8") as f:
+            content_count += len(f.readlines())
+    assert content_count  == len(records)

--- a/tests/Reader/test_reader.py
+++ b/tests/Reader/test_reader.py
@@ -1,10 +1,9 @@
 """Test suite for the Reader class and its backlog."""
 
-from pathlib import Path
-
 import ujson
 
 from dabapush import NDJSONReaderConfiguration, STDOUTWriterConfiguration
+from dabapush.Record import Record
 
 
 def test_backlogging(monkeypatch, tmp_path):
@@ -28,11 +27,7 @@ def test_backlogging(monkeypatch, tmp_path):
             ujson.dump(record, f)  # pylint: disable=I1101
 
     writer.write(reader.read())
-
-    log_path = Path(".dabapush/test/backlog")
-    assert log_path.exists()
-    content_count = 0
-    for file_path in log_path.glob('*.jsonl'):
-        with file_path.open("rt", encoding="utf8") as f:
-            content_count += len(f.readlines())
-    assert content_count  == len(records)
+    for idx in range(3):
+        assert (
+            Record(uuid=(data_dir / f"test{idx}.json:0").as_posix()) in writer.back_log
+        )

--- a/tests/Writer/test_Writer.py
+++ b/tests/Writer/test_Writer.py
@@ -67,5 +67,8 @@ def test_writer_persist_method_with_backlog(isolated_test_dir):
 
     assert not writer.persisted_data
     assert not writer.buffer
-    assert len(writer.back_log) == 10
-    assert all(_.uuid == str(i) for i, _ in enumerate(writer.back_log))
+    backlog_count = 0
+    for _part, uuids in writer.back_log.parts.items():
+        for _uuid in uuids:
+            backlog_count +=1
+    assert backlog_count  == 10

--- a/tests/Writer/test_Writer.py
+++ b/tests/Writer/test_Writer.py
@@ -67,8 +67,5 @@ def test_writer_persist_method_with_backlog(isolated_test_dir):
 
     assert not writer.persisted_data
     assert not writer.buffer
-    backlog_count = 0
-    for _part, uuids in writer.back_log.parts.items():
-        for _uuid in uuids:
-            backlog_count +=1
-    assert backlog_count  == 10
+    for record in queue:
+        assert record in writer.back_log

--- a/tests/Writer/test_stdout_writer.py
+++ b/tests/Writer/test_stdout_writer.py
@@ -4,7 +4,7 @@ from dabapush import STDOUTWriterConfiguration
 from dabapush.Record import Record
 
 
-def test_stdout_writer(capsys):
+def test_stdout_writer(capsys, isolated_test_dir):  # pylint: disable=unused-argument
     """Should write to stdout."""
     writer = STDOUTWriterConfiguration("stdout1").get_instance()
     writer.buffer = [Record(uuid="test.01", source=None, payload="test")]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def isolated_test_dir(monkeypatch, tmp_path):
     """Create an isolated test tmp-directory."""
     monkeypatch.chdir(tmp_path)

--- a/tests/test_backlog.py
+++ b/tests/test_backlog.py
@@ -1,13 +1,14 @@
-# pylint: disable=redefined-outer-name,protected-access,unused-argument
+# pylint: disable=redefined-outer-name,protected-access,unused-argument,c-extension-no-member
 """Test for the Backlog"""
 from pathlib import Path
+from sqlite3 import connect
+
+import pytest
+import ujson
+
 from dabapush.Backlog import Backlog, BacklogLockedException
 from dabapush.Configuration.WriterConfiguration import WriterConfiguration
 from dabapush.Record import Record
-
-import pytest
-
-from ujson import dump, loads
 
 name_writer = "backlog_writer_for_test"
 
@@ -20,96 +21,75 @@ def writer_config():
 
 @pytest.fixture
 def uuids():
+    "Fixture providing a list of uuids."
     return [f"uuid_{idx:02d}" for idx in range(20)]
 
 
 @pytest.fixture
 def existing_log(isolated_test_dir, uuids):
-    dabapush_dir = Path('.dabapush')
+    "Fixture providing a log in the old ndjson format."
+    dabapush_dir = Path(".dabapush")
     dabapush_dir.mkdir()
-    with open(dabapush_dir/f"{name_writer}.jsonl", "wt", encoding="utf8") as test_file:
+    with open(
+        dabapush_dir / f"{name_writer}.jsonl", "wt", encoding="utf8"
+    ) as test_file:
         for uuid in uuids:
-            dump({"uuid": uuid}, test_file)
+            ujson.dump({"uuid": uuid}, test_file)
             test_file.write("\n")
 
 
-def test_contains_empty_parts(writer_config):
+def test_contains_empty_parts(writer_config, isolated_test_dir):
     "Record missing from backlog is correctly reported."
-    backlog = Backlog(
-        len_prefix_persist=2, len_prefix_memory=2, writer_config=writer_config
-    )
-    record = Record(uuid="some_id")
+    backlog = Backlog(writer_config=writer_config)
+    backlog.load()
+    record = Record(uuid="missing_id")
     assert record not in backlog
 
 
-def test_contains(writer_config):
+def test_contains(writer_config, isolated_test_dir):
     "Record present in the backlog is correctly reported."
-    backlog = Backlog(
-        len_prefix_persist=2, len_prefix_memory=2, writer_config=writer_config
-    )
+    backlog = Backlog(writer_config=writer_config)
+    backlog.load()
     record = Record(uuid="some_id")
-    backlog._store_in_memory(record.to_log())
+    backlog.write_record(record)
     assert record in backlog
 
 
-def test_conversion(existing_log,  writer_config):
+def test_conversion(existing_log, writer_config):
     "Test the conversion from old log format to new log format."
-    backlog = Backlog(
-        len_prefix_persist=2, len_prefix_memory=2, writer_config=writer_config
-    )
+    backlog = Backlog(writer_config=writer_config)
     backlog.load()
     dabapush_pth = Path(".dabapush")
     old_log_path = dabapush_pth / f"{name_writer}.jsonl"
     assert not old_log_path.exists()
-    log_dir = dabapush_pth / name_writer/"backlog"
-    assert log_dir.is_dir()
+    db_pth = dabapush_pth / name_writer / "backlog" / "backlog.sqlite3"
+    assert db_pth.is_file()
     all_uuids = []
-    for pth in log_dir.glob('*.jsonl'):
-        with pth.open("rt", encoding="utf8") as part_file:
-            for line in part_file.readlines():
-                json = loads(line)
-                uuid = json["uuid"]
-                all_uuids.append(uuid)
+    query = connect(db_pth.as_posix()).execute("SELECT uuid FROM dabapush_backlog")
+    for item in query:
+        all_uuids.append(item[0])
     assert len(all_uuids) == 20
     assert len(set(all_uuids)) == 20
 
+
 def test_write_and_load_backlog(uuids, isolated_test_dir, writer_config):
     "Test reopening a backlog"
-    backlog = Backlog(
-        len_prefix_persist=2, len_prefix_memory=2, writer_config=writer_config
-    )
+    backlog = Backlog(writer_config=writer_config)
     backlog.load()
     for uuid in uuids:
         backlog.write_record(Record(uuid=uuid))
-    all_uuids = []
-    for _part, uuid_set in backlog.parts.items():
-        for uuid in uuid_set:
-            all_uuids.append(uuid)
-    assert len(all_uuids) ==20
-    all_uuid_set = set(all_uuids)
-    assert len(all_uuid_set) == 20
-    backlog.close()
-    read_backlog = Backlog(
-        len_prefix_persist=2, len_prefix_memory=2, writer_config=writer_config
-    )
-    read_backlog.load()
-    all_read_uuids = []
-    for _part, uuid_set in backlog.parts.items():
-        for uuid in uuid_set:
-            all_read_uuids.append(uuid)
-    assert len(all_read_uuids)==20
-    assert set(all_read_uuids) == all_uuid_set
 
+    backlog.close()
+    read_backlog = Backlog(writer_config=writer_config)
+    read_backlog.load()
+    for uuid in uuids:
+        assert Record(uuid=uuid) in read_backlog
 
 
 def test_does_not_open_when_locked(isolated_test_dir, writer_config):
     "Make sure a locked backlog is not loaded."
-    backlog = Backlog(
-        len_prefix_persist=2, len_prefix_memory=2, writer_config=writer_config
-    )
+    backlog = Backlog(writer_config=writer_config)
     backlog.load()
-    read_backlog = Backlog(
-        len_prefix_persist=2, len_prefix_memory=2, writer_config=writer_config
-    )
+    read_backlog = Backlog(writer_config=writer_config)
     with pytest.raises(BacklogLockedException):
         read_backlog.load()

--- a/tests/test_backlog.py
+++ b/tests/test_backlog.py
@@ -1,7 +1,7 @@
 # pylint: disable=redefined-outer-name,protected-access,unused-argument,c-extension-no-member
 """Test for the Backlog"""
+import dbm
 from pathlib import Path
-from sqlite3 import connect
 
 import pytest
 import ujson
@@ -55,20 +55,17 @@ def test_contains(writer_config, isolated_test_dir):
     assert record in backlog
 
 
-def test_conversion(existing_log, writer_config):
-    "Test the conversion from old log format to new log format."
+def test_conversion(existing_log, writer_config, isolated_test_dir):
+    """Test the conversion from old log format to new log format."""
     backlog = Backlog(writer_config=writer_config)
     backlog.load()
     dabapush_pth = Path(".dabapush")
     old_log_path = dabapush_pth / f"{name_writer}.jsonl"
     assert not old_log_path.exists()
     assert old_log_path.with_suffix(".jsonl.old").exists()
-    db_pth = dabapush_pth / name_writer / "backlog" / "backlog.sqlite3"
+    db_pth = dabapush_pth / name_writer / "backlog" / "backlog.db"
     assert db_pth.is_file()
-    all_uuids = []
-    query = connect(db_pth.as_posix()).execute("SELECT uuid FROM dabapush_backlog")
-    for item in query:
-        all_uuids.append(item[0])
+    all_uuids = dbm.open(db_pth.as_posix(), "r").keys()
     assert len(all_uuids) == 20
     assert len(set(all_uuids)) == 20
 

--- a/tests/test_backlog.py
+++ b/tests/test_backlog.py
@@ -59,6 +59,9 @@ def test_conversion(existing_log, writer_config, isolated_test_dir):
     """Test the conversion from old log format to new log format."""
     backlog = Backlog(writer_config=writer_config)
     backlog.load()
+
+    del backlog
+
     dabapush_pth = Path(".dabapush")
     old_log_path = dabapush_pth / f"{name_writer}.jsonl"
     assert not old_log_path.exists()

--- a/tests/test_backlog.py
+++ b/tests/test_backlog.py
@@ -62,6 +62,7 @@ def test_conversion(existing_log, writer_config):
     dabapush_pth = Path(".dabapush")
     old_log_path = dabapush_pth / f"{name_writer}.jsonl"
     assert not old_log_path.exists()
+    assert old_log_path.with_suffix(".jsonl.old").exists()
     db_pth = dabapush_pth / name_writer / "backlog" / "backlog.sqlite3"
     assert db_pth.is_file()
     all_uuids = []

--- a/tests/test_backlog.py
+++ b/tests/test_backlog.py
@@ -1,0 +1,115 @@
+# pylint: disable=redefined-outer-name,protected-access,unused-argument
+"""Test for the Backlog"""
+from pathlib import Path
+from dabapush.Backlog import Backlog, BacklogLockedException
+from dabapush.Configuration.WriterConfiguration import WriterConfiguration
+from dabapush.Record import Record
+
+import pytest
+
+from ujson import dump, loads
+
+name_writer = "backlog_writer_for_test"
+
+
+@pytest.fixture
+def writer_config():
+    "A simple writer configuration for tests"
+    return WriterConfiguration(name=name_writer)
+
+
+@pytest.fixture
+def uuids():
+    return [f"uuid_{idx:02d}" for idx in range(20)]
+
+
+@pytest.fixture
+def existing_log(isolated_test_dir, uuids):
+    dabapush_dir = Path('.dabapush')
+    dabapush_dir.mkdir()
+    with open(dabapush_dir/f"{name_writer}.jsonl", "wt", encoding="utf8") as test_file:
+        for uuid in uuids:
+            dump({"uuid": uuid}, test_file)
+            test_file.write("\n")
+
+
+def test_contains_empty_parts(writer_config):
+    "Record missing from backlog is correctly reported."
+    backlog = Backlog(
+        len_prefix_persist=2, len_prefix_memory=2, writer_config=writer_config
+    )
+    record = Record(uuid="some_id")
+    assert record not in backlog
+
+
+def test_contains(writer_config):
+    "Record present in the backlog is correctly reported."
+    backlog = Backlog(
+        len_prefix_persist=2, len_prefix_memory=2, writer_config=writer_config
+    )
+    record = Record(uuid="some_id")
+    backlog._store_in_memory(record.to_log())
+    assert record in backlog
+
+
+def test_conversion(existing_log,  writer_config):
+    "Test the conversion from old log format to new log format."
+    backlog = Backlog(
+        len_prefix_persist=2, len_prefix_memory=2, writer_config=writer_config
+    )
+    backlog.load()
+    dabapush_pth = Path(".dabapush")
+    old_log_path = dabapush_pth / f"{name_writer}.jsonl"
+    assert not old_log_path.exists()
+    log_dir = dabapush_pth / name_writer/"backlog"
+    assert log_dir.is_dir()
+    all_uuids = []
+    for pth in log_dir.glob('*.jsonl'):
+        with pth.open("rt", encoding="utf8") as part_file:
+            for line in part_file.readlines():
+                json = loads(line)
+                uuid = json["uuid"]
+                all_uuids.append(uuid)
+    assert len(all_uuids) == 20
+    assert len(set(all_uuids)) == 20
+
+def test_write_and_load_backlog(uuids, isolated_test_dir, writer_config):
+    "Test reopening a backlog"
+    backlog = Backlog(
+        len_prefix_persist=2, len_prefix_memory=2, writer_config=writer_config
+    )
+    backlog.load()
+    for uuid in uuids:
+        backlog.write_record(Record(uuid=uuid))
+    all_uuids = []
+    for _part, uuid_set in backlog.parts.items():
+        for uuid in uuid_set:
+            all_uuids.append(uuid)
+    assert len(all_uuids) ==20
+    all_uuid_set = set(all_uuids)
+    assert len(all_uuid_set) == 20
+    backlog.close()
+    read_backlog = Backlog(
+        len_prefix_persist=2, len_prefix_memory=2, writer_config=writer_config
+    )
+    read_backlog.load()
+    all_read_uuids = []
+    for _part, uuid_set in backlog.parts.items():
+        for uuid in uuid_set:
+            all_read_uuids.append(uuid)
+    assert len(all_read_uuids)==20
+    assert set(all_read_uuids) == all_uuid_set
+
+
+
+def test_does_not_open_when_locked(isolated_test_dir, writer_config):
+    "Make sure a locked backlog is not loaded."
+    backlog = Backlog(
+        len_prefix_persist=2, len_prefix_memory=2, writer_config=writer_config
+    )
+    backlog.load()
+    read_backlog = Backlog(
+        len_prefix_persist=2, len_prefix_memory=2, writer_config=writer_config
+    )
+    with pytest.raises(BacklogLockedException):
+        read_backlog.load()


### PR DESCRIPTION
Same functionality as #78 and #79 but uses GDM as a backend. This has the advantage of using GNU GDM on Linux machines, however, it still provides sqlite3 as a fallback if no other DBM implementation is found.